### PR TITLE
Add template for 'metadata' on SSCC forms

### DIFF
--- a/forms/xsl/sscc.xsl
+++ b/forms/xsl/sscc.xsl
@@ -15,10 +15,12 @@
   </html>
   </xsl:template>
 
+	<xsl:template match="metadata">
+	</xsl:template>
+
   <xsl:template match="form">
 
     <div class="form">
-
       <div class="leftbar bordered padded pull-left">
 
         <div class="bordered centered">


### PR DESCRIPTION
## Why are we doing this?

Fixing a found bug.

SSCC has an event tomorrow so I was checking that their configuration and forms were working correctly. I noticed at the top of the forms page there was an extra line being printed that was not a part of the forms.

![Screen Shot 2020-01-11 at 12 16 12 PM](https://user-images.githubusercontent.com/1305168/72208778-91799c80-346c-11ea-8952-91107a3e89f9.png)

This bug is visible on the live site:
- Log in
- Under _System_ > _Change Organization_ switch to _Sierra Sports Car Club_
- Go to _Events_
- For the Jan. 12 2020 event, click _Action_ then _Entry Forms_

The data on the live site will not match the screenshots I am including as the screenshots are from the development site using an old event. I tracked this down to something specific to the `xsl` for SSCC's forms by testing it against AZBR's set up and seeing that both the AZBR and ASRG `xsl` already have the additional lines being added with this PR.

This PR adds a line to the `xsl` fill to suppress the unstyled `xml` tags that are not accounted for in the template interpretation.

## How can someone view these changes?

Screenshot of fix on dev, which currently has this branch checked out:

![Screen Shot 2020-01-11 at 12 17 44 PM](https://user-images.githubusercontent.com/1305168/72208824-18c71000-346d-11ea-941e-f504569495f3.png)

No random line of dollar amounts (entry fees)!

To verify, follow the path described in the prior section on the dev site and using a past event for SSCC that has at least 1 entry.

## What possible risks or adverse effects are there?

None. This addition is consistent with what is in other `xsl` files that are not demonstrating this bug.

## What are the follow-up tasks?

I noticed that I left the `dev` site checked out on an old branch (`import`) which was showing another bug I'd already resolved. Noting here that once this is merged and deployed to clean things up and checkout `master` on the devsite again.

In `htdocs/devreg.azbrscca.org:
```
git checkout `master`
git pull
git fetch --prune
git branch -D form-bugs
```

## Are there any known issues?

Nope!