### PR TITLE
Paypal links

### DIFF
--- a/events/registered.html
+++ b/events/registered.html
@@ -95,7 +95,7 @@
             -->
 
 <?php if ( isset( $entry_fees ) ) { 
-        if( $orgIsAzbr ) {?>
+        if( $orgIsAzbr ) { ?>
           <div class="span4">
               <h4>Entry Feeeeees</h4>
               <div class="well well-small">
@@ -180,7 +180,7 @@
                 </div>
               </div>
             </div>
-<?php } else {?>
+<?php } else { ?>
             <div class="span4">
               <h4>Entry Fees</h4>
               <div class="well well-small">

--- a/events/registered.html
+++ b/events/registered.html
@@ -151,43 +151,35 @@
                     <?php if( $orgIsAzbr ) { 
                       if ( $registration[ 'entrant_scca_status' ] == 1  ) {
                         if( $registration[ 'entry_fee' ] == 30 ) { ?>
-                          <!--
                           <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                           <input type="hidden" name="cmd" value="_s-xclick">
-                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="hidden" name="hosted_button_id" value="9JCHFM4ZXT6AG">
                           <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                           <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                          </form> -->
-                          THA 30
+                          </form>
                         <?php } else if ( $registration[ 'entry_fee' ] == 40 ) { ?>
-                          <!--
                           <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                           <input type="hidden" name="cmd" value="_s-xclick">
-                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="hidden" name="hosted_button_id" value="EASWPKGAUB6HY">
                           <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                           <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                          </form> -->
-                          THA 40 BUT MEMBER
+                          </form>
                         <?php } ?>
                       <?php } else { 
                         if( $registration[ 'entry_fee' ] == 40 ) { ?>
-                        <!--
                           <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                           <input type="hidden" name="cmd" value="_s-xclick">
                           <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
                           <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                           <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                          </form> -->
-                          THA 40 BUT NONMEMBER
+                          </form>
                         <?php } else if ( $registration[ 'entry_fee' ] == 50 ) { ?>
-                          <!--
                           <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
                           <input type="hidden" name="cmd" value="_s-xclick">
-                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="hidden" name="hosted_button_id" value="VYQZ5UML7B3ZE">
                           <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
                           <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-                          </form> -->
-                          THA 50
+                          </form>
                         <?php } ?>
                       <?php } ?>
                     <?php } ?>

--- a/events/registered.html
+++ b/events/registered.html
@@ -35,6 +35,8 @@
 
   $admin = json_decode( $event[ 'admin' ], true );
   $tos = ( $event[ 'time_only_reg' ] == 1 );
+  
+  $orgIsAzbr = ( $event[ 'organization_id' ] == 2 );
 
   if ( !empty( $event[ 'entry_fees' ] ) ) {
     $entry_fees = json_decode( $event[ 'entry_fees' ], true );
@@ -92,7 +94,93 @@
             </div>
             -->
 
-<?php if ( isset( $entry_fees ) ) { ?>
+<?php if ( isset( $entry_fees ) ) { 
+        if( $orgIsAzbr ) {?>
+          <div class="span4">
+              <h4>Entry Feeeeees</h4>
+              <div class="well well-small">
+                <table class="table table-bordered table-condensed">
+                  <tr>
+                    <td><strong>SCCA Members</strong></td>
+                    <td><strong>Competition</strong></td>
+                    <?php if ( $tos ) { ?>
+                    <td><strong>Time Only</strong></td>
+                    <?php } ?>
+                  </tr>
+                  <tr>
+                    <td>Registering Online</td>
+                    <td>$ <?php echo $entry_fees[ 'scca_comp_online' ]; ?></td>
+                    <?php if ( $tos ) { ?>
+                    <td>$ <?php echo $entry_fees[ 'scca_to_online' ]; ?></td>
+                    <?php } ?>
+                  </tr>
+                  <tr>
+                    <td>Registering On Site</td>
+                    <td>$ <?php echo $entry_fees[ 'scca_comp_onsite' ]; ?></td>
+                    <?php if ( $tos ) { ?>
+                    <td>$ <?php echo $entry_fees[ 'scca_to_onsite' ]; ?></td>
+                    <?php } ?>
+                  </tr>
+
+                  <tr>
+                    <td><strong>Non SCCA Members</strong></td>
+                    <td><strong>Competition</strong></td>
+                    <?php if ( $tos ) { ?>
+                    <td><strong>Time Only</strong></td>
+                    <?php } ?>
+                  </tr>
+                  <tr>
+                    <td>Registering Online</td>
+                    <td>$ <?php echo $entry_fees[ 'wknd_comp_online' ]; ?></td>
+                    <?php if ( $tos ) { ?>
+                    <td>$ <?php echo $entry_fees[ 'wknd_to_online' ]; ?></td>
+                    <?php } ?>
+                  </tr>
+                  <tr>
+                    <td>Registering On Site</td>
+                    <td>$ <?php echo $entry_fees[ 'wknd_comp_onsite' ]; ?></td>
+                    <?php if ( $tos ) { ?>
+                    <td>$ <?php echo $entry_fees[ 'wknd_to_onsite' ]; ?></td>
+                    <?php } ?>
+                  </tr>
+                </table>
+                <div>
+                  <p>
+                    <strong>
+                      Your Entry Fee: <i class="icon-usd"></i> <?php echo number_format( $registration[ 'entry_fee' ], 2 ); ?>
+                    </strong>
+                  </p>
+                  <p>
+                    <?php if ( $entry_fees['online_conditional'] == 1 ) { ?>
+                    Entry fee above valid only if paid online prior to the close of registration
+                    <?php } ?>
+                  </p>
+                  <p>
+                  <ul>
+                    <li>
+                      SCCA Membership:
+                      <?php if ( $registration[ 'entrant_scca_status' ] == 1  ) { ?>
+                      <span class="text-success">Verified</span>
+                      <?php } else if ( $registration[ 'entrant_scca_number' ] == "" ) { ?>
+                      No membership number entered.
+                      <?php } else { ?>
+                      <span class="text-warning">Could not verify!</span>
+                      <?php } ?>
+                    </li>
+                    <?php if ( $tos ) { ?>
+                    <li>
+                      Time Only Registration:
+                      <?php if ( $registration[ 'time_only_reg' ] == 1 ) { ?>
+                      Yes
+                      <?php } else { ?>
+                      No
+                      <?php } ?>
+                    </li>
+                    <?php } ?>
+                </div>
+              </div>
+            </div>
+<?php } else {?>
             <div class="span4">
               <h4>Entry Fees</h4>
               <div class="well well-small">

--- a/events/registered.html
+++ b/events/registered.html
@@ -95,92 +95,6 @@
             -->
 
 <?php if ( isset( $entry_fees ) ) { ?>
-<?php if( $orgIsAzbr ) { ?>
-          <div class="span4">
-              <h4>Entry Feeeeees</h4>
-              <div class="well well-small">
-                <table class="table table-bordered table-condensed">
-                  <tr>
-                    <td><strong>SCCA Members</strong></td>
-                    <td><strong>Competition</strong></td>
-                    <?php if ( $tos ) { ?>
-                    <td><strong>Time Only</strong></td>
-                    <?php } ?>
-                  </tr>
-                  <tr>
-                    <td>Registering Online</td>
-                    <td>$ <?php echo $entry_fees[ 'scca_comp_online' ]; ?></td>
-                    <?php if ( $tos ) { ?>
-                    <td>$ <?php echo $entry_fees[ 'scca_to_online' ]; ?></td>
-                    <?php } ?>
-                  </tr>
-                  <tr>
-                    <td>Registering On Site</td>
-                    <td>$ <?php echo $entry_fees[ 'scca_comp_onsite' ]; ?></td>
-                    <?php if ( $tos ) { ?>
-                    <td>$ <?php echo $entry_fees[ 'scca_to_onsite' ]; ?></td>
-                    <?php } ?>
-                  </tr>
-
-                  <tr>
-                    <td><strong>Non SCCA Members</strong></td>
-                    <td><strong>Competition</strong></td>
-                    <?php if ( $tos ) { ?>
-                    <td><strong>Time Only</strong></td>
-                    <?php } ?>
-                  </tr>
-                  <tr>
-                    <td>Registering Online</td>
-                    <td>$ <?php echo $entry_fees[ 'wknd_comp_online' ]; ?></td>
-                    <?php if ( $tos ) { ?>
-                    <td>$ <?php echo $entry_fees[ 'wknd_to_online' ]; ?></td>
-                    <?php } ?>
-                  </tr>
-                  <tr>
-                    <td>Registering On Site</td>
-                    <td>$ <?php echo $entry_fees[ 'wknd_comp_onsite' ]; ?></td>
-                    <?php if ( $tos ) { ?>
-                    <td>$ <?php echo $entry_fees[ 'wknd_to_onsite' ]; ?></td>
-                    <?php } ?>
-                  </tr>
-                </table>
-                <div>
-                  <p>
-                    <strong>
-                      Your Entry Fee: <i class="icon-usd"></i> <?php echo number_format( $registration[ 'entry_fee' ], 2 ); ?>
-                    </strong>
-                  </p>
-                  <p>
-                    <?php if ( $entry_fees['online_conditional'] == 1 ) { ?>
-                    Entry fee above valid only if paid online prior to the close of registration
-                    <?php } ?>
-                  </p>
-                  <p>
-                  <ul>
-                    <li>
-                      SCCA Membership:
-                      <?php if ( $registration[ 'entrant_scca_status' ] == 1  ) { ?>
-                      <span class="text-success">Verified</span>
-                      <?php } else if ( $registration[ 'entrant_scca_number' ] == "" ) { ?>
-                      No membership number entered.
-                      <?php } else { ?>
-                      <span class="text-warning">Could not verify!</span>
-                      <?php } ?>
-                    </li>
-                    <?php if ( $tos ) { ?>
-                    <li>
-                      Time Only Registration:
-                      <?php if ( $registration[ 'time_only_reg' ] == 1 ) { ?>
-                      Yes
-                      <?php } else { ?>
-                      No
-                      <?php } ?>
-                    </li>
-                    <?php } ?>
-                </div>
-              </div>
-            </div>
-<?php } else { ?>
             <div class="span4">
               <h4>Entry Fees</h4>
               <div class="well well-small">
@@ -234,6 +148,49 @@
                     <strong>
                       Your Entry Fee: <i class="icon-usd"></i> <?php echo number_format( $registration[ 'entry_fee' ], 2 ); ?>
                     </strong>
+                    <?php if( $orgIsAzbr ) { 
+                      if ( $registration[ 'entrant_scca_status' ] == 1  ) {
+                        if( $registration[ 'entry_fee' ] == 30 ) { ?>
+                          <!--
+                          <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                          <input type="hidden" name="cmd" value="_s-xclick">
+                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                          <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                          </form> -->
+                          THA 30
+                        <?php } else if ( $registration[ 'entry_fee' ] == 40 ) { ?>
+                          <!--
+                          <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                          <input type="hidden" name="cmd" value="_s-xclick">
+                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                          <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                          </form> -->
+                          THA 40 BUT MEMBER
+                        <?php } ?>
+                      <?php } else { 
+                        if( $registration[ 'entry_fee' ] == 40 ) { ?>
+                        <!--
+                          <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                          <input type="hidden" name="cmd" value="_s-xclick">
+                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                          <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                          </form> -->
+                          THA 40 BUT NONMEMBER
+                        <?php } else if ( $registration[ 'entry_fee' ] == 50 ) { ?>
+                          <!--
+                          <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
+                          <input type="hidden" name="cmd" value="_s-xclick">
+                          <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+                          <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
+                          <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
+                          </form> -->
+                          THA 50
+                        <?php } ?>
+                      <?php } ?>
+                    <?php } ?>
                   </p>
                   <p>
                     <?php if ( $entry_fees['online_conditional'] == 1 ) { ?>
@@ -265,7 +222,6 @@
                 </div>
               </div>
             </div>
-<?php } ?>
 <?php } ?>
 
 <?php if ( !empty( $event[ 'payment_info' ] ) ) { ?>

--- a/events/registered.html
+++ b/events/registered.html
@@ -94,8 +94,8 @@
             </div>
             -->
 
-<?php if ( isset( $entry_fees ) ) { 
-        if( $orgIsAzbr ) { ?>
+<?php if ( isset( $entry_fees ) ) { ?>
+<?php if( $orgIsAzbr ) { ?>
           <div class="span4">
               <h4>Entry Feeeeees</h4>
               <div class="well well-small">
@@ -265,6 +265,7 @@
                 </div>
               </div>
             </div>
+<?php } ?>
 <?php } ?>
 
 <?php if ( !empty( $event[ 'payment_info' ] ) ) { ?>

--- a/org/events/edit.html
+++ b/org/events/edit.html
@@ -303,8 +303,8 @@
                   <div class="span12">
 
 										<div class="alert alert-info">
-											<strong>Event Specific Supplimental Regulations</strong>
-                      <p>Use this area to create supplimental regulations for this specific event. If this area is left blank, the organization's default supplimental regulations block will be displayed on the registration page</p>
+											<strong>Event Specific Supplemental Regulations</strong>
+                      <p>Use this area to create supplemental regulations for this specific event. If this area is left blank, the organization's default supplemental regulations block will be displayed on the registration page</p>
                     </div>
 
 										<div class="row-fluid">
@@ -315,7 +315,7 @@
 											</div>
 
 											<div class="span6">
-												<h4>Event Supplimental Regulations</h4>
+												<h4>Event Supplemental Regulations</h4>
                         <div class="alert">
                           <p><i class="icon-warning-sign"></i> Please ensure you read and understand the supplemental regulations for <?php echo $org[ 'name' ]; ?> Events.</p>
                           <?php if ( $org[ 'supps_url' ] != "" ) { ?>

--- a/register/index.html
+++ b/register/index.html
@@ -935,7 +935,7 @@
                       p.append( $( "<i/>", { 'class' : "icon-info-sign" } ) );
                       p.append( " The " + category.name + " category does not allow cars in class " + sccaClass.name + "." );
                       p.append( " You will be allowed to complete your registration, however you may be required to change your car class and/or category at the event. " );
-                      p.append( " Please refer to the <?php echo $event[ 'organization_name' ]; ?> Supplimental Regulations for more information." );
+                      p.append( " Please refer to the <?php echo $event[ 'organization_name' ]; ?> Supplemental Regulations for more information." );
                       $( "#info-div" ).append( p );
                       if ( $( "#info-div" ).is( ":hidden" ) ) {
                         $( "#info-div" ).slideDown();
@@ -949,7 +949,7 @@
                   p.append( $( "<i/>", { 'class' : "icon-info-sign" } ) );
                   p.append( " The category you have selected does not allow Competition/Race tires. Please adjust your competition category selection or the indicated type tire of your car. " );
                   p.append( " You will be allowed to complete your registration, however you may be required to change your car class and/or category at the event. " );
-                  p.append( " Please refer to the <?php echo $event[ 'organization_name' ]; ?> Supplimental Regulations for more information." );
+                  p.append( " Please refer to the <?php echo $event[ 'organization_name' ]; ?> Supplemental Regulations for more information." );
                   $( "#info-div" ).append( p );
 
                   valid = false;


### PR DESCRIPTION
## Why are we doing this?

A major source of reg issues has been people submitting the wrong paypal amount compared to their entry details (member vs non member, TO vs non-TO). This PR adds intelligence to the "registered" page so that people always get the correct link.

## How can someone view these changes?

devreg.azbrscca.org

Steps to manually verify the change:

Try the change out with a SCCA verified member w/wo TOs, then with a dummy non SCCA member w/wo TOs.

## What possible risks or adverse effects are there?

People might have incorrect registration details if they screw up their entry, then they will have the wrong link. I can't fix stupid though.

## What are the follow-up tasks?

* Think about how to get two days of awesome in here (really hard though)
* Think about how to genericize this logic so that orgs can add their own buttons for their own prices

## Are there any known issues?

If we change reg fees, this logic doesn't work and would need to be updated
