### PR TITLE
fix: updated paypal button logic for weekend member price increase

### DIFF
--- a/common/PaypalButtonHelper.php
+++ b/common/PaypalButtonHelper.php
@@ -8,6 +8,10 @@
       $event_id = $event[ 'id' ];
       $entrant_id = $registration[ 'entrant_id' ];
       $totalRemainingEntryFee = $registration[ 'entry_fee' ];
+
+      // TODO: for a two day event, change the event IDs here. Note that the paypal button logic
+      // for two day events is out of date with respect to price; both the buttons and the logic
+      // need to be updated.
       $event_id_2da1 = 484;
       $event_id_2da2 = 485;
       $buttonDelivered = false;
@@ -179,7 +183,7 @@
             <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
             <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
             </form>
-          <?php } else if ( $totalRemainingEntryFee == 57 ) { 
+          <?php } else if ( $totalRemainingEntryFee == 62 ) { 
             $buttonDelivered = true;?>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
             <input type="hidden" name="cmd" value="_s-xclick" />
@@ -190,7 +194,7 @@
             <input type="hidden" name="currency_code" value="USD" />
             <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
             </form>
-          <?php } else if ( $totalRemainingEntryFee == 67 ) { 
+          <?php } else if ( $totalRemainingEntryFee == 72 ) { 
             $buttonDelivered = true;?>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
             <input type="hidden" name="cmd" value="_s-xclick" />


### PR DESCRIPTION
## Why are we doing this?

SCCA National raised weekend membership prices by $5. Update the paypal button logic to compensate so that users are presented with the right price and button link after registering.

## How can someone view these changes?

Dev registration site (already tested)

Steps to manually verify the change:

Register for a test event with no SCCA member number entered. Do this with and without TOs (already tested)

## What possible risks or adverse effects are there?

If this breaks, weekend members cannot pay after registration.

## What are the follow-up tasks?

* Next step is PC member pricing logic with a discount code

## Are there any known issues?

dev reg site does not support SCCA member number entry so you can't verify that the logic didn't break for annual SCCA members.
