### PR TITLE
Mreysser/discount codes

### DIFF
--- a/api/controllers/DbController.php
+++ b/api/controllers/DbController.php
@@ -6,6 +6,7 @@
       "comp_categories",
       "comp_groups",
       "discounts",
+      "discount_codes",
       "entry_forms",
       "events",
       "event_types",

--- a/common/PaypalButtonHelper.php
+++ b/common/PaypalButtonHelper.php
@@ -25,12 +25,16 @@
       
       if( $registeredForBoth ) {
         //We need to calculate the Two Days of Awesome entry fee. The discount is $10. However, weekend members get a break on the $10 weekend member fee, so their discount is $20
+        // TODO: if you want additional discount codes to apply to the two days of awesome, more work is needed here.
         if ( $registration[ 'entrant_scca_status' ] == 1  ) {
           $totalRemainingEntryFee = -10;
         } else {
           $totalRemainingEntryFee = -20;
         }
         $totalRemainingEntryFee = $totalRemainingEntryFee + DatabaseHelper::getEntrantEntryFee($entrant_id, $event_id_2da1) + DatabaseHelper::getEntrantEntryFee($entrant_id, $event_id_2da2);
+      } else {
+        // Check if the user has submitted a valid discount code, apply it if so
+        $totalRemainingEntryFee = $totalRemainingEntryFee - PaypalButtonHelper::getDiscountAmount($event, $registration);
       }
       ?>
       <strong>
@@ -114,28 +118,18 @@
       } else {
         // Single event reg only - SCCA members
         if ( $registration[ 'entrant_scca_status' ] == 1  ) {
-          if( $totalRemainingEntryFee == 30 ) { 
+          if( $totalRemainingEntryFee == 20 ) { 
+            // This button is for Podium Club members who are also SCCA members.
             $buttonDelivered = true;?>
-            <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="9JCHFM4ZXT6AG">
+            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick" />
+            <input type="hidden" name="hosted_button_id" value="SDQ7ZT7QKCL9A" />
             <table>
-            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
+            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxLength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
             </table>
-            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-            </form>
-          <?php } else if ( $totalRemainingEntryFee == 40 ) { 
-            $buttonDelivered = true;?>
-            <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="EASWPKGAUB6HY">
-            <table>
-            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
-            </table>
-            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-            </form>
+            <input type="hidden" name="currency_code" value="USD" />
+            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
+          </form>
           <?php } else if ( $totalRemainingEntryFee == 42 ) { 
             $buttonDelivered = true;?>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -161,28 +155,18 @@
           <?php } ?>
         <?php } else {
           // Single event reg only - weekend members
-          if( $totalRemainingEntryFee == 45 ) { 
+          if( $totalRemainingEntryFee == 40 ) { 
+            // This button is for Podium Club members who are Weekend SCCA members
             $buttonDelivered = true;?>
-            <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="MCT4HMFYRQYNE">
+            <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
+            <input type="hidden" name="cmd" value="_s-xclick" />
+            <input type="hidden" name="hosted_button_id" value="ABBRHDRPUYE74" />
             <table>
-            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
+            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxLength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
             </table>
-            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-            </form>
-          <?php } else if ( $totalRemainingEntryFee == 55 ) { 
-            $buttonDelivered = true;?>
-            <form target="paypal" action="https://www.paypal.com/cgi-bin/webscr" method="post">
-            <input type="hidden" name="cmd" value="_s-xclick">
-            <input type="hidden" name="hosted_button_id" value="VYQZ5UML7B3ZE">
-            <table>
-            <tr><td><input type="hidden" name="on0" value="Driver name">Driver name</td></tr><tr><td><input type="text" name="os0" maxlength="200" value="<?php echo $registration[ 'entrant_name_first' ], " ", $registration[ 'entrant_name_last' ]?>"></td></tr>
-            </table>
-            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-            <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-            </form>
+            <input type="hidden" name="currency_code" value="USD" />
+            <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_cart_LG.gif" border="0" name="submit" title="PayPal - The safer, easier way to pay online!" alt="Add to Cart" />
+          </form>
           <?php } else if ( $totalRemainingEntryFee == 62 ) { 
             $buttonDelivered = true;?>
             <form action="https://www.paypal.com/cgi-bin/webscr" method="post" target="_blank">
@@ -221,6 +205,25 @@
           Please send a PayPal payment to payments@azbrscca.org to complete payment
         <?php }
       }
+    }
+
+    private static function getDiscountAmount( $event, $registration ) {
+      if( $registration[ 'discount_code' ] == '' ) {
+        return 0;
+      }
+      $q = new Query( "discount_codes" );
+      $q->addWhere( 'code', $registration[ 'discount_code' ] );
+      $retrievedDiscount = $q->selectOne();
+      if( $retrievedDiscount == NULL ) {
+        return 0;
+      }
+      // TODO: this logic does not take advantage of the stuff in the schema. For now this gets us going with Podium Club events.
+      // Also in the future we need to filter by event location.
+      $discountAmount = $retrievedDiscount[ 'discount_value' ];
+      if( $discountAmount > 0 ) {
+        return $discountAmount;
+      }
+      return 0;
     }
 
   } // class PaypalButtonHelper

--- a/register/index.html
+++ b/register/index.html
@@ -139,7 +139,10 @@
       }
     }
     $registration[ 'entry_fee' ] = $fee;
-    /* / calculate entry fee */
+    /* 
+      calculate entry fee. note that discounts are handled
+      by the paypal button helper.
+    */
 
     /*
       check for registration id in case the user
@@ -226,7 +229,7 @@
         <div class="span12">
           <div class="alert">
             <i class="icon-warning-sign icon-large"></i>
-            2023 SCCA rules no longer allow ECE helmets! All helmets must be Snell SA or M rated, 2010 or newer.
+            All helmets must be Snell SA or M rated, 2010 or newer. 2026 is the last year that the Snell 2010 helmets will be accepted. 
             Please review the
             <a href="<?php echo baseHref; ?>register/2023_helmets.pdf" target="_blank">Required Helmet Certification Decals</a>
             quick reference sheet published by the SCCA. Check the decal on your helmet ensure that your helmet will be legal <em>before</em> you show up to an event!
@@ -755,6 +758,13 @@
                       <div class="text-warning"><i class="icon-warning-sign icon-large"></i> Completing this field does <strong>not</strong> register co-drivers for the event!</div>
                       <span id="codriver-help"><i class="icon-info-sign icon-large"></i> More Information</span>
                     </div>
+                  </div>
+                </div>
+
+                <div class="control-group" id="registration_discount_code-cg">
+                  <label class="control-label" for="registration_discount_code">Discount Code (if applicable)</label>
+                  <div class="controls">
+                    <input class="input-xlarge" id="registration_discount_code" name="registration[discount_code]" type="text" />
                   </div>
                 </div>
 <?php } else { ?>


### PR DESCRIPTION
## Why are we doing this?

We need to provide Podium Club members access to events at Podium Club at cost. The easiest way to do that is via a discount code we share with them privately.

This adds a discount code text field to the registration form, and then uses a new DB table with discount codes to apply the discount when selecting the paypal button to display. This is very minimal and has some limitations:
- does not work correctly if TOs are enabled
- does not limit this discount code to Podium Club events only
- does not work for two days of awesome
- does not work for anything other than a fixed discount (X dollars off the normal price)
- probably other limitations I'm forgetting, this is honestly "bubble gum and popsicle sticks" territory

## How can someone view these changes?

dev registration site

Steps to manually verify the change:

1. Register for an event as normal, leave discount code empty. Should be normal prices
2. Register for an event as an SCCA member with the PC discount code. Should be $20
3. Register for an event as a weekend SCCA member with the PC discount code. Should be $40

## What possible risks or adverse effects are there?

I'm reasonably confident this does not break registration flow e.g. people can still register successfully for the event. The bigger risk is around displaying the correct vs incorrect paypal button, or if things break enough there will be no paypal button.

## What are the follow-up tasks?

* Short term: fix the TO limitation in time for a February event
* Medium term: fix the discount codes so they can be applied on a per-site basis 
* Long term: fix all the other limitations

## Are there any known issues?

See limitations above. Otherwise everything should work correctly.
